### PR TITLE
Replace shadowsocks-libev&v2ray to shadowsocks-rust&xray-plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN set -ex\
     && wget -O /root/shadowsocks-plugin.tar.xz https://github.com/shadowsocks/shadowsocks-rust/releases/download/${SHADOWSOCKS_VERSION}/shadowsocks-${SHADOWSOCKS_VERSION}.x86_64-unknown-linux-musl.tar.xz \
     && tar xvf /root/shadowsocks-plugin.tar.xz -C /root \
     && mv /root/ss* /usr/local/bin/ \
-    && rm -f /root/shadowsocks-plugin.tar.xz \
-    && apk del wget
+    && rm -f /root/shadowsocks-plugin.tar.xz
 
 CMD /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ COPY conf/ /conf
 COPY entrypoint.sh /entrypoint.sh
 
 RUN set -ex\
-    && apk add --no-cache libqrencode wget nginx jq \
-    && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \ 
+    && apk add --no-cache libqrencode wget nginx jq bash \
     && chmod +x /entrypoint.sh \
     && mkdir -p /etc/shadowsocks-libev /etc/nginx/conf.d /wwwroot \
     && wget -O /root/xray-plugin.tar.gz https://github.com/teddysun/xray-plugin/releases/download/${XRAY_PLUGIN_VERSION}/xray-plugin-linux-amd64-${XRAY_PLUGIN_VERSION}.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN set -ex\
     && apk add --no-cache libqrencode wget nginx jq \
-    && rm /etc/nginx/http.d/default.conf \
     && chmod +x /entrypoint.sh \
     && mkdir -p /etc/shadowsocks-libev /wwwroot \
     && wget -O /root/xray-plugin.tar.gz https://github.com/teddysun/xray-plugin/releases/download/${XRAY_PLUGIN_VERSION}/xray-plugin-linux-amd64-${XRAY_PLUGIN_VERSION}.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,23 @@
-FROM debian:sid
+FROM alpine:3.16
 
-ARG V2RAY_VERSION=v1.3.1
+ENV XRAY_PLUGIN_VERSION v1.5.5
+ENV SHADOWSOCKS_VERSION v1.14.3
 
 COPY conf/ /conf
 COPY entrypoint.sh /entrypoint.sh
 
-ARG DEBIAN_FRONTEND=noninteractive
 RUN set -ex\
-    && apt update -y \
-    && apt install -y wget qrencode shadowsocks-libev nginx-light jq \
-    && apt clean -y \
+    && apk add --no-cache qrencode wget nginx jq \
     && chmod +x /entrypoint.sh \
-    && mkdir -p /etc/shadowsocks-libev /v2raybin /wwwroot \
-    && wget -O- "https://github.com/shadowsocks/v2ray-plugin/releases/download/${V2RAY_VERSION}/v2ray-plugin-linux-amd64-${V2RAY_VERSION}.tar.gz" | \
-        tar zx -C /v2raybin \
-    && install /v2raybin/v2ray-plugin_linux_amd64 /usr/bin/v2ray-plugin \
-    && rm -rf /v2raybin
+    && mkdir -p /etc/shadowsocks-libev /wwwroot \
+    && wget -O /root/xray-plugin.tar.gz https://github.com/teddysun/xray-plugin/releases/download/${XRAY_PLUGIN_VERSION}/xray-plugin-linux-amd64-${XRAY_PLUGIN_VERSION}.tar.gz \
+    && tar xvzf /root/xray-plugin.tar.gz -C /root \
+    && mv /root/xray-plugin_linux_amd64 /usr/local/bin/xray-plugin \
+    && rm -f /root/xray-plugin.tar.gz \
+    && wget -O /root/shadowsocks-plugin.tar.xz https://github.com/shadowsocks/shadowsocks-rust/releases/download/${SHADOWSOCKS_VERSION}/shadowsocks-${SHADOWSOCKS_VERSION}.x86_64-unknown-linux-musl.tar.xz \
+    && tar xvf /root/shadowsocks-plugin.tar.xz -C /root \
+    && mv /root/ss* /usr/local/bin/ \
+    && rm -f /root/shadowsocks-plugin.tar.xz \
+    && apk del wget
 
 CMD /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY entrypoint.sh /entrypoint.sh
 RUN set -ex\
     && apk add --no-cache libqrencode wget nginx jq \
     && chmod +x /entrypoint.sh \
-    && mkdir -p /etc/shadowsocks-libev /wwwroot \
+    && mkdir -p /etc/shadowsocks-libev /etc/nginx/conf.d /wwwroot \
     && wget -O /root/xray-plugin.tar.gz https://github.com/teddysun/xray-plugin/releases/download/${XRAY_PLUGIN_VERSION}/xray-plugin-linux-amd64-${XRAY_PLUGIN_VERSION}.tar.gz \
     && tar xvzf /root/xray-plugin.tar.gz -C /root \
     && mv /root/xray-plugin_linux_amd64 /usr/local/bin/xray-plugin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM alpine:3.16
 
 ENV XRAY_PLUGIN_VERSION v1.5.5
 ENV SHADOWSOCKS_VERSION v1.14.3
@@ -7,9 +7,9 @@ COPY conf/ /conf
 COPY entrypoint.sh /entrypoint.sh
 
 RUN set -ex\
-    && apk add --no-cache libqrencode wget jq \
+    && apk add --no-cache libqrencode wget nginx jq \
     && chmod +x /entrypoint.sh \
-    && mkdir -p /etc/shadowsocks-libev /etc/nginx/conf.d /wwwroot \
+    && mkdir -p /etc/shadowsocks-libev /wwwroot \
     && wget -O /root/xray-plugin.tar.gz https://github.com/teddysun/xray-plugin/releases/download/${XRAY_PLUGIN_VERSION}/xray-plugin-linux-amd64-${XRAY_PLUGIN_VERSION}.tar.gz \
     && tar xvzf /root/xray-plugin.tar.gz -C /root \
     && mv /root/xray-plugin_linux_amd64 /usr/local/bin/xray-plugin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN set -ex\
     && apk add --no-cache libqrencode wget nginx jq \
+    && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \ 
     && chmod +x /entrypoint.sh \
     && mkdir -p /etc/shadowsocks-libev /etc/nginx/conf.d /wwwroot \
     && wget -O /root/xray-plugin.tar.gz https://github.com/teddysun/xray-plugin/releases/download/${XRAY_PLUGIN_VERSION}/xray-plugin-linux-amd64-${XRAY_PLUGIN_VERSION}.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN set -ex\
     && apk add --no-cache libqrencode wget nginx jq \
+    && rm /etc/nginx/http.d/default.conf \
     && chmod +x /entrypoint.sh \
     && mkdir -p /etc/shadowsocks-libev /wwwroot \
     && wget -O /root/xray-plugin.tar.gz https://github.com/teddysun/xray-plugin/releases/download/${XRAY_PLUGIN_VERSION}/xray-plugin-linux-amd64-${XRAY_PLUGIN_VERSION}.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM nginx:alpine
 
 ENV XRAY_PLUGIN_VERSION v1.5.5
 ENV SHADOWSOCKS_VERSION v1.14.3
@@ -7,7 +7,7 @@ COPY conf/ /conf
 COPY entrypoint.sh /entrypoint.sh
 
 RUN set -ex\
-    && apk add --no-cache libqrencode wget nginx jq bash \
+    && apk add --no-cache libqrencode wget jq \
     && chmod +x /entrypoint.sh \
     && mkdir -p /etc/shadowsocks-libev /etc/nginx/conf.d /wwwroot \
     && wget -O /root/xray-plugin.tar.gz https://github.com/teddysun/xray-plugin/releases/download/${XRAY_PLUGIN_VERSION}/xray-plugin-linux-amd64-${XRAY_PLUGIN_VERSION}.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY conf/ /conf
 COPY entrypoint.sh /entrypoint.sh
 
 RUN set -ex\
-    && apk add --no-cache qrencode wget nginx jq \
+    && apk add --no-cache libqrencode wget nginx jq \
     && chmod +x /entrypoint.sh \
     && mkdir -p /etc/shadowsocks-libev /wwwroot \
     && wget -O /root/xray-plugin.tar.gz https://github.com/teddysun/xray-plugin/releases/download/${XRAY_PLUGIN_VERSION}/xray-plugin-linux-amd64-${XRAY_PLUGIN_VERSION}.tar.gz \
@@ -17,6 +17,7 @@ RUN set -ex\
     && wget -O /root/shadowsocks-plugin.tar.xz https://github.com/shadowsocks/shadowsocks-rust/releases/download/${SHADOWSOCKS_VERSION}/shadowsocks-${SHADOWSOCKS_VERSION}.x86_64-unknown-linux-musl.tar.xz \
     && tar xvf /root/shadowsocks-plugin.tar.xz -C /root \
     && mv /root/ss* /usr/local/bin/ \
-    && rm -f /root/shadowsocks-plugin.tar.xz
+    && rm -f /root/shadowsocks-plugin.tar.xz \
+    && apk del wget
 
 CMD /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Personal VPN
-## Shadowsocks+V2Ray-plugin
+## [shadowsocks-rust](https://github.com/shadowsocks/shadowsocks-rust)+[xray-plugin](https://github.com/teddysun/xray-plugin)
 
 Click the button below to deploy to Heroku
 
@@ -50,9 +50,9 @@ Path: "/" + value of V2_Path in app Config Vars
 
 Those without a client can also download from here (Android):
 
-[shadowsocks](https://github.com/shadowsocks/shadowsocks-android/releases/latest/download/shadowsocks--universal-5.1.9.apk)
+[shadowsocks](https://github.com/shadowsocks/shadowsocks-android/releases/latest/)
 
-[v2ray-plugin](https://github.com/shadowsocks/v2ray-plugin-android/releases/latest/download/v2ray-arm64-v8a-1.3.1.apk)
+[v2ray-plugin](https://github.com/shadowsocks/v2ray-plugin-android/releases/latest/)
 
 windows:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Click the button below to deploy to Heroku
 
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/abubaca4/shadowsocks-heroku/tree/main)
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
 ## 0. Attention
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Click the button below to deploy to Heroku
 
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/Snawoot/shadowsocks-heroku/tree/main)
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/abubaca4/shadowsocks-heroku/tree/main)
 
 ## 0. Attention
 

--- a/conf/nginx_ss.conf
+++ b/conf/nginx_ss.conf
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 cat <<EOF
 server {
     listen       ${PORT};

--- a/conf/nginx_ss.conf
+++ b/conf/nginx_ss.conf
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cat <<EOF
 server {
     listen       ${PORT};

--- a/conf/shadowsocks-libev_config.json
+++ b/conf/shadowsocks-libev_config.json
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Fast_open must be false on heroku
 cat <<EOF
 {

--- a/conf/shadowsocks-libev_config.json
+++ b/conf/shadowsocks-libev_config.json
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Fast_open must be false on heroku
 cat <<EOF
 {

--- a/conf/shadowsocks-libev_config.json
+++ b/conf/shadowsocks-libev_config.json
@@ -3,7 +3,7 @@
 cat <<EOF
 {
     "server": "127.0.0.1",
-    "server_port": "2333",
+    "server_port": 2333,
     "password": $(echo -n "$PASSWORD" | jq -Rc),
     "timeout": 300,
     "method": "${ENCRYPT}",

--- a/conf/shadowsocks-libev_config.json
+++ b/conf/shadowsocks-libev_config.json
@@ -11,7 +11,7 @@ cat <<EOF
     "fast_open":false,
     "reuse_port":true,
     "no_delay":true,
-    "plugin": "v2ray-plugin",
+    "plugin": "xray-plugin",
     "plugin_opts":"server;path=/${V2_Path}"
 }
 EOF

--- a/conf/shadowsocks-libev_config.json
+++ b/conf/shadowsocks-libev_config.json
@@ -4,7 +4,7 @@ cat <<EOF
 {
     "server": "127.0.0.1",
     "server_port": "2333",
-    "password": ${PASSWORD_JSON},
+    "password": "$(echo -n "$PASSWORD" | jq -Rc)",
     "timeout": 300,
     "method": "${ENCRYPT}",
     "mode": "tcp_only",

--- a/conf/shadowsocks-libev_config.json
+++ b/conf/shadowsocks-libev_config.json
@@ -4,7 +4,7 @@ cat <<EOF
 {
     "server": "127.0.0.1",
     "server_port": "2333",
-    "password": "$(echo -n "$PASSWORD" | jq -Rc)",
+    "password": $(echo -n "$PASSWORD" | jq -Rc),
     "timeout": 300,
     "method": "${ENCRYPT}",
     "mode": "tcp_only",

--- a/conf/shadowsocks-libev_config.json
+++ b/conf/shadowsocks-libev_config.json
@@ -2,16 +2,16 @@
 # Fast_open must be false on heroku
 cat <<EOF
 {
-    "server":"127.0.0.1",
-    "server_port":"2333",
-    "password":${PASSWORD_JSON},
-    "timeout":300,
-    "method":"${ENCRYPT}",
+    "server": "127.0.0.1",
+    "server_port": "2333",
+    "password": "${PASSWORD_JSON}",
+    "timeout": 300,
+    "method": "${ENCRYPT}",
     "mode": "tcp_only",
-    "fast_open":false,
-    "reuse_port":true,
-    "no_delay":true,
+    "fast_open": false,
+    "reuse_port": true,
+    "no_delay": true,
     "plugin": "xray-plugin",
-    "plugin_opts":"server;path=/${V2_Path}"
+    "plugin_opts": "server;path=/${V2_Path}"
 }
 EOF

--- a/conf/shadowsocks-libev_config.json
+++ b/conf/shadowsocks-libev_config.json
@@ -4,7 +4,7 @@ cat <<EOF
 {
     "server": "127.0.0.1",
     "server_port": "2333",
-    "password": "${PASSWORD_JSON}",
+    "password": ${PASSWORD_JSON},
     "timeout": 300,
     "method": "${ENCRYPT}",
     "mode": "tcp_only",

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,9 +34,9 @@ sh /conf/shadowsocks-libev_config.json >  /etc/shadowsocks-libev/config.json
 echo /etc/shadowsocks-libev/config.json
 cat /etc/shadowsocks-libev/config.json
 
-sh /conf/nginx_ss.conf > /etc/nginx/sites-enabled/ss.conf
-echo /etc/nginx/sites-enabled/ss.conf
-cat /etc/nginx/sites-enabled/ss.conf
+sh /conf/nginx_ss.conf > /etc/nginx/http.d/ss.conf
+echo /etc/nginx/http.d/ss.conf
+cat /etc/nginx/http.d/ss.conf
 
 
 if [ "$AppName" = "no" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,9 +34,9 @@ sh /conf/shadowsocks-libev_config.json >  /etc/shadowsocks-libev/config.json
 echo /etc/shadowsocks-libev/config.json
 cat /etc/shadowsocks-libev/config.json
 
-sh /conf/nginx_ss.conf > /etc/nginx/conf.d/ss.conf
-echo /etc/nginx/conf.d/ss.conf
-cat /etc/nginx/conf.d/ss.conf
+sh /conf/nginx_ss.conf > /etc/nginx/sites-enabled/ss.conf
+echo /etc/nginx/sites-enabled/ss.conf
+cat /etc/nginx/sites-enabled/ss.conf
 
 
 if [ "$AppName" = "no" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [[ -z "${PASSWORD}" ]]; then
   export PASSWORD="5c301bb8-6c77-41a0-a606-4ba11bbab084"
@@ -30,11 +30,11 @@ case "$AppName" in
 		;;
 esac
 
-bash /conf/shadowsocks-libev_config.json >  /etc/shadowsocks-libev/config.json
+sh /conf/shadowsocks-libev_config.json >  /etc/shadowsocks-libev/config.json
 echo /etc/shadowsocks-libev/config.json
 cat /etc/shadowsocks-libev/config.json
 
-bash /conf/nginx_ss.conf > /etc/nginx/conf.d/ss.conf
+sh /conf/nginx_ss.conf > /etc/nginx/conf.d/ss.conf
 echo /etc/nginx/conf.d/ss.conf
 cat /etc/nginx/conf.d/ss.conf
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,8 +5,6 @@ if [[ -z "${PASSWORD}" ]]; then
 fi
 echo ${PASSWORD}
 
-echo export PASSWORD_JSON="$(echo -n "$PASSWORD" | jq -Rc)"
-
 if [[ -z "${ENCRYPT}" ]]; then
   export ENCRYPT="chacha20-ietf-poly1305"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ if [[ -z "${PASSWORD}" ]]; then
 fi
 echo ${PASSWORD}
 
-export PASSWORD_JSON="$(echo -n "$PASSWORD" | jq -Rc)"
+echo export PASSWORD_JSON="$(echo -n "$PASSWORD" | jq -Rc)"
 
 if [[ -z "${ENCRYPT}" ]]; then
   export ENCRYPT="chacha20-ietf-poly1305"
@@ -30,7 +30,7 @@ case "$AppName" in
 		;;
 esac
 
-sh /conf/shadowsocks-libev_config.json >  /etc/shadowsocks-libev/config.json
+sh /conf/shadowsocks-libev_config.json > /etc/shadowsocks-libev/config.json
 echo /etc/shadowsocks-libev/config.json
 cat /etc/shadowsocks-libev/config.json
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,12 +43,12 @@ if [ "$AppName" = "no" ]; then
   echo "Do not generate QR-code"
 else
   [ ! -d /wwwroot/${QR_Path} ] && mkdir /wwwroot/${QR_Path}
-  plugin=$(echo -n "xray-plugin;path=/${V2_Path};host=${DOMAIN};tls" | sed -e 's/\//%2F/g' -e 's/=/%3D/g' -e 's/;/%3B/g')
+  plugin=$(echo -n "v2ray;path=/${V2_Path};host=${DOMAIN};tls" | sed -e 's/\//%2F/g' -e 's/=/%3D/g' -e 's/;/%3B/g')
   ss="ss://$(echo -n ${ENCRYPT}:${PASSWORD} | base64 -w 0)@${DOMAIN}:443?plugin=${plugin}" 
   echo "${ss}" | tr -d '\n' > /wwwroot/${QR_Path}/index.html
   echo -n "${ss}" | qrencode -s 6 -o /wwwroot/${QR_Path}/vpn.png
 fi
 
 ssserver -c /etc/shadowsocks-libev/config.json &
-rm -rf /etc/nginx/sites-enabled/default
+rm -rf /etc/nginx/http.d/default.conf
 nginx -g 'daemon off;'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [[ -z "${PASSWORD}" ]]; then
   export PASSWORD="5c301bb8-6c77-41a0-a606-4ba11bbab084"
@@ -30,11 +30,11 @@ case "$AppName" in
 		;;
 esac
 
-bash /conf/shadowsocks-libev_config.json >  /etc/shadowsocks-libev/config.json
+sh /conf/shadowsocks-libev_config.json >  /etc/shadowsocks-libev/config.json
 echo /etc/shadowsocks-libev/config.json
 cat /etc/shadowsocks-libev/config.json
 
-bash /conf/nginx_ss.conf > /etc/nginx/conf.d/ss.conf
+sh /conf/nginx_ss.conf > /etc/nginx/conf.d/ss.conf
 echo /etc/nginx/conf.d/ss.conf
 cat /etc/nginx/conf.d/ss.conf
 
@@ -43,12 +43,12 @@ if [ "$AppName" = "no" ]; then
   echo "Do not generate QR-code"
 else
   [ ! -d /wwwroot/${QR_Path} ] && mkdir /wwwroot/${QR_Path}
-  plugin=$(echo -n "v2ray;path=/${V2_Path};host=${DOMAIN};tls" | sed -e 's/\//%2F/g' -e 's/=/%3D/g' -e 's/;/%3B/g')
+  plugin=$(echo -n "xray-plugin;path=/${V2_Path};host=${DOMAIN};tls" | sed -e 's/\//%2F/g' -e 's/=/%3D/g' -e 's/;/%3B/g')
   ss="ss://$(echo -n ${ENCRYPT}:${PASSWORD} | base64 -w 0)@${DOMAIN}:443?plugin=${plugin}" 
   echo "${ss}" | tr -d '\n' > /wwwroot/${QR_Path}/index.html
   echo -n "${ss}" | qrencode -s 6 -o /wwwroot/${QR_Path}/vpn.png
 fi
 
-ss-server -c /etc/shadowsocks-libev/config.json &
+ssserver -c /etc/shadowsocks-libev/config.json &
 rm -rf /etc/nginx/sites-enabled/default
 nginx -g 'daemon off;'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [[ -z "${PASSWORD}" ]]; then
   export PASSWORD="5c301bb8-6c77-41a0-a606-4ba11bbab084"
@@ -30,11 +30,11 @@ case "$AppName" in
 		;;
 esac
 
-sh /conf/shadowsocks-libev_config.json >  /etc/shadowsocks-libev/config.json
+bash /conf/shadowsocks-libev_config.json >  /etc/shadowsocks-libev/config.json
 echo /etc/shadowsocks-libev/config.json
 cat /etc/shadowsocks-libev/config.json
 
-sh /conf/nginx_ss.conf > /etc/nginx/conf.d/ss.conf
+bash /conf/nginx_ss.conf > /etc/nginx/conf.d/ss.conf
 echo /etc/nginx/conf.d/ss.conf
 cat /etc/nginx/conf.d/ss.conf
 


### PR DESCRIPTION
# Changes
## Why shadowsocks-rust
According to [shadowsocks-libev](https://github.com/shadowsocks/shadowsocks-libev) about future development moved to [shadowsocks-rust](https://github.com/shadowsocks/shadowsocks-rust). 
## Why xray-plugin
[V2ray](https://github.com/shadowsocks/v2ray-plugin) not updated a long time. [Xray-plugin](https://github.com/teddysun/xray-plugin) protocol backward compatible with v2ray, v2ray clients can connect to xray.
## Why alpine
Much smaller base image. Now builded image has only 48 mb size. It can be reduced more with removing unused shadowsocks-rust apps(like sslocal).
## Links to android app in README.md
Current links incorrect, replaced with links to last release page(not direct to apk).
## Why leave v2ray for clients
In Play Market it's only v2ray plugin, no xray.
# Need be checked
## Is full domain name still can be specified
I use sh, not bash and something in entrypoint.sh can go wrong.
## Is moving PASSWORD escaping direct to shadowsocks-libev_config.json is necessary
ssserver did not accept config a long time and I thought problem was in password string. Really problem was in qoutes around server_port. I don't remove changes with PASSWORD escaping.

### Heroku blocked my account after I tested this changes so I can't check all in "Need be checked" by myshelf.